### PR TITLE
added missing cstdint includes + fixed narrowing conversion error on RISC-V platform

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -65,3 +65,6 @@
 [submodule "libs/googletest"]
 	path = libs/googletest
 	url = https://github.com/google/googletest.git
+[submodule "libs/base64rvv"]
+	path = libs/base64rvv
+	url = https://github.com/vogma/Base64

--- a/src/A.Hristov/ahristov.h
+++ b/src/A.Hristov/ahristov.h
@@ -1,4 +1,5 @@
 #include <string>
+#include <cstdint>
 /**
  * Given a string, this function will encode it in 64b (with padding)
  */

--- a/src/ElegantDice/ElegantDice.h
+++ b/src/ElegantDice/ElegantDice.h
@@ -2,6 +2,7 @@
 
 #include <vector>
 #include <string>
+#include <cstdint>
 
 void base64_encode(std::string & out, const std::vector<std::uint8_t>& buf);
 void base64_encode(std::string & out, const std::uint8_t* buf, size_t bufLen);

--- a/src/omnifarious/omnifarious.h
+++ b/src/omnifarious/omnifarious.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <cstdint>
 ::std::string base64_encode(const ::std::string &bindata);
 ::std::string base64_encode(const char *bytes, size_t length);
 ::std::string base64_decode(const ::std::string &ascdata);

--- a/src/tomykaria/tomykaria.hpp
+++ b/src/tomykaria/tomykaria.hpp
@@ -24,6 +24,7 @@
  */
 //https://gist.github.com/tomykaira/f0fd86b6c73063283afe550bc5d77594
 #include <string>
+#include <cstdint>
 
 namespace macaron {
 

--- a/src/user152949/user152949.h
+++ b/src/user152949/user152949.h
@@ -10,7 +10,7 @@ public:
 	static inline const char encodeCharacterTable[65] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
 	/** Static Base64 character decoding lookup table */
-	static inline const char decodeCharacterTable[256] = {
+	static inline const signed char decodeCharacterTable[256] = {
 	-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1
 	,-1,62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-1,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21
 	,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,-1,-1,-1,-1,-1,


### PR DESCRIPTION
This pull request includes two small changes.

1. On all the machines i tested on (2x x86 and 1x RISC-V), i got errors about missing cstdint includes in the project when using the gcc compiler. I added the missing includes to the header files.
2. When compiling the benchmark-suite on a RISC-V architecture, a narrowing conversion error occurs. This PR adds an explicit signed to the corresponding char array.